### PR TITLE
Fix volume calculation in first `desired_samples`

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -68,7 +68,7 @@ void TrimToLoudestSegment(const std::vector<float>& input,
   float current_volume_sum = 0.0f;
   for (int64_t i = 0; i < desired_samples; ++i) {
     const float input_value = input[i];
-    current_volume_sum += fabsf(input_value * input_value);
+    current_volume_sum += fabsf(input_value);
   }
   int64_t loudest_end_index = desired_samples;
   float loudest_volume = current_volume_sum;


### PR DESCRIPTION
Commit 1f2eb73 replaces `sqrtf(x*x)` with `fabsf(x)` to calculate volume.
In one instance, `sqrtf(x*x)` was accidentally replaced with `fabsf(x*x)`
instead of `fabsf(x)`. This change fixes that instance.